### PR TITLE
Implementing a moving data window functionality for liveAttrs:

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require (
 	github.com/czcorpus/cnc-gokit v0.13.0
 	github.com/czcorpus/rexplorer v0.0.8
-	github.com/czcorpus/vert-tagextract/v3 v3.1.3
+	github.com/czcorpus/vert-tagextract/v3 v3.2.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-sql-driver/mysql v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/czcorpus/cnc-gokit v0.13.0 h1:1WmKVDibQvSJciPJuMUjlZCcIBP279+sOMvw8bz
 github.com/czcorpus/cnc-gokit v0.13.0/go.mod h1:BZSRrYUFIHXVIiuqnSoZbfXfL2X/gHWG3w35aIVW36U=
 github.com/czcorpus/rexplorer v0.0.8 h1:rxBivMmo10xGlCDaxzH9IeD23YzS8QM5cyTXiEFPllE=
 github.com/czcorpus/rexplorer v0.0.8/go.mod h1:9KwJWUp9tqn5gDjN3sS2jcsaaMWsfi3qPaqN5s9DY9Y=
-github.com/czcorpus/vert-tagextract/v3 v3.1.3 h1:WiswP6J9R/1vS9h4S87PFIztw9cHvLvJon90hz7rwpU=
-github.com/czcorpus/vert-tagextract/v3 v3.1.3/go.mod h1:1twSh9ZvmAkCOG3XAig+e4MvVQZmSH8HOwHdLf0zlsM=
+github.com/czcorpus/vert-tagextract/v3 v3.2.0 h1:uRNgE9duBtnLsZrQ1VsIhAszXIu3sPPZzXAzc9PV4/U=
+github.com/czcorpus/vert-tagextract/v3 v3.2.0/go.mod h1:1twSh9ZvmAkCOG3XAig+e4MvVQZmSH8HOwHdLf0zlsM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/liveattrs/actions/data.go
+++ b/liveattrs/actions/data.go
@@ -63,6 +63,15 @@ func (a *Actions) Create(ctx *gin.Context) {
 		return
 	}
 
+	if err := jsonArgs.ValidateDataWindow(); err != nil {
+		uniresp.RespondWithErrorJSON(
+			ctx,
+			err,
+			http.StatusBadRequest,
+		)
+		return
+	}
+
 	if conf == nil {
 		var newConf *vteCnf.VTEConf
 		var err error

--- a/liveattrs/actions/main.go
+++ b/liveattrs/actions/main.go
@@ -151,6 +151,14 @@ func (a *Actions) applyPatchArgs(
 		targetConf.SelfJoin = *jsonArgs.SelfJoin
 	}
 
+	if jsonArgs.RemoveEntriesBeforeDate != nil {
+		targetConf.RemoveEntriesBeforeDate = jsonArgs.RemoveEntriesBeforeDate
+	}
+
+	if jsonArgs.DatetimeAttr != nil {
+		targetConf.DatetimeAttr = jsonArgs.DatetimeAttr
+	}
+
 	return nil
 }
 

--- a/liveattrs/laconf/patch.go
+++ b/liveattrs/laconf/patch.go
@@ -17,8 +17,15 @@
 package laconf
 
 import (
+	"fmt"
+	"regexp"
+
 	vteCnf "github.com/czcorpus/vert-tagextract/v3/cnf"
 	vteDb "github.com/czcorpus/vert-tagextract/v3/db"
+)
+
+var (
+	dateFormatRegexp = regexp.MustCompile(`[0-9]{4}-[0-9]{2}-[0-9]{2}`)
 )
 
 // PatchArgs is a subset of vert-tagextract's VTEConf
@@ -37,12 +44,26 @@ import (
 //
 // Note: the most important self join functions are: "identity", "intecorp"
 type PatchArgs struct {
-	VerticalFiles []string            `json:"verticalFiles"`
-	MaxNumErrors  *int                `json:"maxNumErrors"`
-	AtomStructure *string             `json:"atomStructure"`
-	SelfJoin      *vteDb.SelfJoinConf `json:"selfJoin"`
-	BibView       *vteDb.BibViewConf  `json:"bibView"`
-	Ngrams        *vteCnf.NgramConf   `json:"ngrams"`
+	VerticalFiles           []string            `json:"verticalFiles"`
+	DatetimeAttr            *string             `json:"datetimeAttr"`
+	RemoveEntriesBeforeDate *string             `json:"removeEntriesBeforeDate"`
+	MaxNumErrors            *int                `json:"maxNumErrors"`
+	AtomStructure           *string             `json:"atomStructure"`
+	SelfJoin                *vteDb.SelfJoinConf `json:"selfJoin"`
+	BibView                 *vteDb.BibViewConf  `json:"bibView"`
+	Ngrams                  *vteCnf.NgramConf   `json:"ngrams"`
+}
+
+func (la *PatchArgs) ValidateDataWindow() error {
+	if la.RemoveEntriesBeforeDate != nil {
+		if !dateFormatRegexp.MatchString(*la.RemoveEntriesBeforeDate) {
+			return fmt.Errorf("invalid date format (expecting yyyy-mm-dd)")
+		}
+		if la.DatetimeAttr == nil || *la.DatetimeAttr == "" {
+			return fmt.Errorf("removeEntriesBeforeDate must be accompanied by datetimeAttr")
+		}
+	}
+	return nil
 }
 
 func (la *PatchArgs) GetVerticalFiles() []string {


### PR DESCRIPTION
by combining url arg *append* and new json args properties *removeEntriesBeforeDate* and *datetimeAttr*, Frodo (via vert-tagextract library) can remove older records and append new ones which makes processing monitoring corpora more effective (i.e. no need to process everything each time a monit. corpus changes)