### PR TITLE
Two major updates:

### DIFF
--- a/cmd/dictbuilder/types.go
+++ b/cmd/dictbuilder/types.go
@@ -21,17 +21,19 @@ import (
 	vtedb "github.com/czcorpus/vert-tagextract/v3/db"
 )
 
+type apiConf struct {
+	BaseURL string `json:"baseUrl"`
+}
+
 type DictbuilderConfig struct {
-	Logging  logging.LoggingConf `json:"logging"`
-	Database *vtedb.Conf         `json:"database"`
-	API      struct {
-		BaseURL string `json:"baseUrl"`
-	} `json:"api"`
-	NumOfLookbackDays int    `json:"numOfLookbackDays"`
-	VerticalDir       string `json:"verticalDir"`
-	Corpname          string `json:"corpname"`
-	TempCorpname      string `json:"tmpCorpname"`
-	NGramSize         int    `json:"ngramSize"`
+	Logging           logging.LoggingConf `json:"logging"`
+	Database          *vtedb.Conf         `json:"database"`
+	API               apiConf             `json:"api"`
+	NumOfLookbackDays int                 `json:"numOfLookbackDays"`
+	VerticalDir       string              `json:"verticalDir"`
+	Corpname          string              `json:"corpname"`
+	TempCorpname      string              `json:"tmpCorpname"`
+	NGramSize         int                 `json:"ngramSize"`
 }
 
 type JobStatus struct {

--- a/cncdb/cncdb.go
+++ b/cncdb/cncdb.go
@@ -242,6 +242,26 @@ func (c *CNCMySQLHandler) UnsetLiveAttrs(transact *sql.Tx, corpus string) error 
 	return err
 }
 
+// LoadAliasedInfo loads info of corpus aliasOf as if it were corpus corpusID - i.e. the
+// data will be from aliasOf except for the name.
+// It is ok to provide an empty aliasOf in which case, the behavior will be just like
+// when calling LoadInfo
+func (c *CNCMySQLHandler) LoadAliasedInfo(corpusID, aliasOf string) (*corpus.DBInfo, error) {
+	var ans *corpus.DBInfo
+	var err error
+	if aliasOf != "" {
+		ans, err = c.LoadInfo(aliasOf)
+		if err != nil {
+			return nil, err
+		}
+		ans.Name = corpusID
+		return ans, nil
+
+	} else {
+		return c.LoadInfo(corpusID)
+	}
+}
+
 func (c *CNCMySQLHandler) LoadInfo(corpusID string) (*corpus.DBInfo, error) {
 	srch, ok := c.corpusInfoCache[corpusID]
 	if ok {

--- a/corpus/info.go
+++ b/corpus/info.go
@@ -57,7 +57,7 @@ func (info *DBInfo) GroupedName() string {
 func GetRegistry(regPath string) (*parser.Document, error) {
 	regBytes, err := os.ReadFile(regPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed read registry file %s: %w", regPath, err)
+		return nil, fmt.Errorf("failed reading registry file %s: %w", regPath, err)
 	}
 	doc, err := parser.ParseRegistryBytes(filepath.Base(regPath), regBytes)
 	if err != nil {
@@ -128,7 +128,6 @@ func GetCorpusInfo(corpusID string, setup *CorporaSetup, tryLimited bool) (*Info
 	ans.IndexedData = IndexedData{}
 	ans.RegistryConf = RegistryConf{Paths: make([]FileMappedValue, 0, 10)}
 	ans.RegistryConf.SubcorpAttrs = make(map[string][]string)
-
 	corpReg1 := setup.GetFirstValidRegistry(corpusID, CorpusVariantPrimary.SubDir())
 	value, err := bindValueToPath(corpReg1, corpReg1)
 	if err != nil {
@@ -178,10 +177,7 @@ func GetCorpusInfo(corpusID string, setup *CorporaSetup, tryLimited bool) (*Info
 	unparsedStructs := corp1.GetProperty("STRUCTLIST").String()
 	if unparsedStructs != "" {
 		structs := strings.Split(unparsedStructs, ",")
-		ans.IndexedStructs = make([]string, len(structs))
-		for i, st := range structs {
-			ans.IndexedStructs[i] = st
-		}
+		copy(ans.IndexedStructs, structs)
 	}
 
 	// try registry's VERTICAL

--- a/liveattrs/actions/main.go
+++ b/liveattrs/actions/main.go
@@ -124,10 +124,17 @@ func (a *Actions) applyPatchArgs(
 				return fmt.Errorf("invalid n-gram size: %d", jsonArgs.Ngrams.NgramSize)
 			}
 			targetConf.Ngrams = *jsonArgs.Ngrams
-
-		} else if jsonArgs.Ngrams.NgramSize > 0 {
-			return fmt.Errorf("missing columns to extract n-grams from")
 		}
+		if jsonArgs.Ngrams.NgramSize > 0 {
+			targetConf.Ngrams.NgramSize = jsonArgs.Ngrams.NgramSize
+		}
+		if jsonArgs.Ngrams.CalcARF {
+			jsonArgs.Ngrams.CalcARF = true
+		}
+	}
+
+	if targetConf.Ngrams.NgramSize > 0 && len(targetConf.Ngrams.VertColumns) == 0 {
+		return fmt.Errorf("missing columns to extract n-grams from")
 	}
 
 	if jsonArgs.VerticalFiles != nil {


### PR DESCRIPTION
1. for N-grams > 1, always build everything from 1 to N automatically 
2. add support for db name aliases so we can derive multiple LA
   databases from a single corpus