### PR TITLE
Use more recent vert-tagextract for safer data extraction and deployment

### DIFF
--- a/cmd/server/frodo.go
+++ b/cmd/server/frodo.go
@@ -242,6 +242,8 @@ func main() {
 		"/liveAttributes/:corpusId/data", liveattrsActions.Create)
 	engine.DELETE(
 		"/liveAttributes/:corpusId/data", liveattrsActions.Delete)
+	engine.POST(
+		"/liveAttributes/:corpusId/cleanTmpTables", liveattrsActions.CleanTmpTables)
 	engine.GET(
 		"/liveAttributes/:corpusId/conf", liveattrsActions.ViewConf)
 	engine.PUT(

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/czcorpus/cnc-gokit v0.21.0
 	github.com/czcorpus/mquery-common v0.6.3
 	github.com/czcorpus/rexplorer v0.0.8
-	github.com/czcorpus/vert-tagextract/v3 v3.7.0
+	github.com/czcorpus/vert-tagextract/v3 v3.8.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/gin-gonic/gin v1.11.0
 	github.com/go-sql-driver/mysql v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/czcorpus/mquery-common v0.6.3 h1:TofGFqUW7472vD9QL4tAFvGdKKIBAqcr9RsK
 github.com/czcorpus/mquery-common v0.6.3/go.mod h1:jm+a8TUScDmReS+wJGVQpYU2ZsF1c81eMeZVWRzA9iQ=
 github.com/czcorpus/rexplorer v0.0.8 h1:rxBivMmo10xGlCDaxzH9IeD23YzS8QM5cyTXiEFPllE=
 github.com/czcorpus/rexplorer v0.0.8/go.mod h1:9KwJWUp9tqn5gDjN3sS2jcsaaMWsfi3qPaqN5s9DY9Y=
-github.com/czcorpus/vert-tagextract/v3 v3.7.0 h1:ER8h13wiucGzDK9+4CPbIGwNEv+m4tW3C7GQK72xpys=
-github.com/czcorpus/vert-tagextract/v3 v3.7.0/go.mod h1:cHEBLUJ7sBR7+ULeKM5rE8hSy2L7dUPXi3nyT8hjAGE=
+github.com/czcorpus/vert-tagextract/v3 v3.8.0 h1:I4YrccYymVOAdtiMpmhhf7UOSYkdrHwKfXt8Nwm5L04=
+github.com/czcorpus/vert-tagextract/v3 v3.8.0/go.mod h1:cHEBLUJ7sBR7+ULeKM5rE8hSy2L7dUPXi3nyT8hjAGE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/jobs/actions.go
+++ b/jobs/actions.go
@@ -89,6 +89,18 @@ func (a *Actions) createJobList(unfinishedOnly bool) JobInfoList {
 	return ans
 }
 
+func (a *Actions) HasRunningJobs() bool {
+	a.jobListLock.RLock()
+	defer a.jobListLock.RUnlock()
+	for _, v := range a.jobList {
+
+		if !v.IsFinished() {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *Actions) EnqueueJob(fn *QueuedFunc, initialStatus GeneralJobInfo) {
 	a.jobQueueLock.Lock()
 	a.jobQueue.Enqueue(fn, initialStatus)

--- a/liveattrs/actions/data.go
+++ b/liveattrs/actions/data.go
@@ -225,3 +225,39 @@ func (a *Actions) Delete(ctx *gin.Context) {
 	}
 	uniresp.WriteJSONResponse(ctx.Writer, map[string]any{"ok": true})
 }
+
+// CleanTmpTables godoc
+// @Summary      Remove [corpus]_[data type]_new tables
+// @Description  Can be used to reset broken import process. It is allowed to run only if no other job is running.
+// @Produce      json
+// @Param        corpusId path string true "Used corpus"
+// @Success      200 {object} vteCnf.NgramConf
+// @Router       /liveAttributes/{corpusId}/cleanTmpTables [post]
+func (a *Actions) CleanTmpTables(ctx *gin.Context) {
+	if a.jobActions.HasRunningJobs() {
+		uniresp.RespondWithErrorJSON(
+			ctx,
+			fmt.Errorf("cannot run in case there are running jobs"),
+			http.StatusForbidden,
+		)
+		return
+	}
+
+	corpusID := ctx.Param("corpusId")
+
+	if _, err := a.laDB.DB().Exec(
+		fmt.Sprintf("DROP TABLE IF EXISTS %s_liveattrs_entry_new", corpusID),
+	); err != nil {
+		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := a.laDB.DB().Exec(
+		fmt.Sprintf("DROP TABLE IF EXISTS %s_colcounts_new", corpusID),
+	); err != nil {
+		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
+		return
+	}
+
+	uniresp.WriteJSONResponse(ctx.Writer, map[string]bool{"ok": true})
+}


### PR DESCRIPTION
(it generates data into temporary tables and if ok then it renames them to production names)