### PR TITLE
Lexical portal dictionary improvements

### DIFF
--- a/ujc/lex/backend.go
+++ b/ujc/lex/backend.go
@@ -172,7 +172,35 @@ func SearchMatches(ctx context.Context, db *sql.DB, lemma string, source Source)
 	return matches, nil
 }
 
-func SearchVariants(ctx context.Context, db *sql.DB, lemma string) ([]LexItem, error) {
+func SearchAvailableSources(ctx context.Context, db *sql.DB, lemma string) ([]Source, error) {
+	row, err := db.QueryContext(
+		ctx,
+		"SELECT DISTINCT source "+
+			"FROM lex_dictionary "+
+			"WHERE lemma = ?;",
+		lemma,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search available sources: %w", err)
+	}
+	defer row.Close()
+
+	sources := make([]Source, 0)
+	for row.Next() {
+		var source Source
+		if err := row.Scan(&source); err != nil {
+			if err == sql.ErrNoRows {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("failed to scan available source: %w", err)
+		}
+		sources = append(sources, source)
+	}
+
+	return sources, nil
+}
+
+func SearchVariants(ctx context.Context, db *sql.DB, lemma string, source Source) ([]LexItem, error) {
 	row, err := db.QueryContext(
 		ctx,
 		`
@@ -186,20 +214,20 @@ func SearchVariants(ctx context.Context, db *sql.DB, lemma string) ([]LexItem, e
 				SELECT DISTINCT lemma, pos, gender, aspect
 				FROM lex_dictionary AS l
 				JOIN (
-					SELECT DISTINCT group_id, source FROM lex_dictionary WHERE lemma = ? AND group_id IS NOT NULL
+					SELECT DISTINCT group_id, source FROM lex_dictionary WHERE lemma = ? AND source = ? AND group_id IS NOT NULL
 				) AS g
 				ON g.group_id = l.group_id AND g.source = l.source
 				UNION
 				SELECT DISTINCT lemma, pos, gender, aspect
 				FROM lex_dictionary AS l
-				WHERE lemma = ? AND group_id IS NULL
+				WHERE lemma = ? AND source = ? AND group_id IS NULL
 			) AS sub
 			JOIN lex_dictionary AS l2
 			ON l2.lemma = sub.lemma AND l2.pos = sub.pos AND (l2.gender = sub.gender OR (l2.gender IS NULL AND sub.gender IS NULL)) AND (l2.aspect = sub.aspect OR (l2.aspect IS NULL AND sub.aspect IS NULL))
 			GROUP BY lemma, pos, gender, aspect, source
 		) AS sub2
 		GROUP BY lemma, pos, gender, aspect`,
-		lemma, lemma,
+		lemma, source, lemma, source,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to search the term: %w", err)

--- a/ujc/lex/backend.go
+++ b/ujc/lex/backend.go
@@ -72,18 +72,23 @@ const (
 
 var dictionaryTable = `
 CREATE TABLE %s (
-	group_id VARCHAR(100) COLLATE utf8mb4_bin,
+	group_id VARCHAR(100),
 	homonym INT DEFAULT 0,
 
-	lemma VARCHAR(100) COLLATE utf8mb4_bin NOT NULL,
+	lemma VARCHAR(100) NOT NULL,
 	pos VARCHAR(4) NOT NULL,
 	gender VARCHAR(2),
 	aspect VARCHAR(1),
 	
 	source VARCHAR(8) NOT NULL,
 	external_id VARCHAR(100) NOT NULL,
-	external_parent_id VARCHAR(100)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci`
+	external_parent_id VARCHAR(100),
+
+	-- This column automatically calculates the normalized search key
+	search_key VARCHAR(100) COLLATE utf8mb4_unicode_ci GENERATED ALWAYS AS (
+		REPLACE(REPLACE(LOWER(lemma), 'y', 'i'), 'z', 's')
+	) STORED
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`
 
 func CreateTables(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
 	tx, err := db.BeginTx(ctx, nil)
@@ -97,6 +102,33 @@ func CreateTables(ctx context.Context, db *sql.DB) (*sql.Tx, error) {
 		return nil, fmt.Errorf("failed to create table: %w", err)
 	}
 	return tx, nil
+}
+
+func SearchTypoSuggestions(ctx context.Context, db *sql.DB, term string) ([]string, error) {
+	row, err := db.QueryContext(
+		ctx,
+		"SELECT DISTINCT lemma "+
+			"FROM lex_dictionary "+
+			"WHERE search_key = REPLACE(REPLACE(LOWER(?), 'y', 'i'), 'z', 's');",
+		term,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search match: %w", err)
+	}
+	defer row.Close()
+
+	suggestions := make([]string, 0, 5)
+	for row.Next() {
+		var lemma string
+		if err := row.Scan(&lemma); err != nil {
+			if err == sql.ErrNoRows {
+				return suggestions, nil
+			}
+			return nil, fmt.Errorf("failed to scan suggestions: %w", err)
+		}
+		suggestions = append(suggestions, lemma)
+	}
+	return suggestions, nil
 }
 
 func SearchMatches(ctx context.Context, db *sql.DB, lemma string, source Source) ([]dictionary.Lemma, error) {

--- a/ujc/lex/backend.go
+++ b/ujc/lex/backend.go
@@ -118,7 +118,7 @@ func SearchMatches(ctx context.Context, db *sql.DB, lemma string, source Source)
 	for row.Next() {
 		// just bare minimum for WaG to process the match
 		match := dictionary.Lemma{
-			ID:        fmt.Sprintf("match-%s-%d", source, i),
+			ID:        fmt.Sprintf("lex-%s-%d", source, i),
 			Forms:     make([]dictionary.Form, 0, 1),
 			Sublemmas: make([]dictionary.Sublemma, 0, 1),
 		}

--- a/ujc/lex/backend.go
+++ b/ujc/lex/backend.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/agnivade/levenshtein"
+	"github.com/czcorpus/cnc-gokit/collections"
 )
 
 type Source string
@@ -128,6 +129,9 @@ func SearchTypoSuggestions(ctx context.Context, db *sql.DB, term string) ([]stri
 		}
 		suggestions = append(suggestions, lemma)
 	}
+	suggestions = collections.SliceFilter(suggestions, func(v string, i int) bool {
+		return !strings.EqualFold(v, term)
+	})
 	return suggestions, nil
 }
 

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -169,11 +169,36 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	bestMatch := bestMatches[0]
 	suggestions := collections.SliceMap(bestMatches[1:], func(match dictionary.Lemma, i int) string { return match.Lemma })
 
-	lexItems, err := SearchVariants(ctx, actions.db.DB(), bestMatch.Lemma)
+	// find available sources for the best match, and select the main source based on the priority list
+	sources, err := SearchAvailableSources(ctx, actions.db.DB(), bestMatch.Lemma)
 	if err != nil {
 		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
 		return
 	}
+	var mainSource Source
+	for _, source := range actions.sourcePriority {
+		if collections.SliceFindIndex(sources, func(s Source) bool { return s == source }) != -1 {
+			mainSource = source
+			break
+		}
+	}
+	if mainSource == "" {
+		ans := map[string]any{
+			"matches":     []dictionary.Lemma{bestMatch},
+			"suggestions": suggestions,
+		}
+		uniresp.WriteJSONResponse(ctx.Writer, ans)
+		return
+	}
+
+	// search for all variants of the best match in the main source
+	lexItems, err := SearchVariants(ctx, actions.db.DB(), bestMatch.Lemma, mainSource)
+	if err != nil {
+		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
+		return
+	}
+
+	// this should never occur, mainSource should be always available here
 	if lexItems == nil {
 		ans := map[string]any{
 			"matches":     []dictionary.Lemma{bestMatch},
@@ -183,20 +208,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 		return
 	}
 
-	var mainSource Source
-	// filter data by source priority
-	for _, source := range actions.sourcePriority {
-		filtered := collections.SliceFilter(lexItems, func(lexItem LexItem, i int) bool {
-			_, ok := lexItem.Sources[source]
-			return ok
-		})
-		if len(filtered) > 0 {
-			lexItems = filtered
-			mainSource = source
-			break
-		}
-	}
-
+	// for each variant, search for its entry in the corpus, if not found, create a new entry with minimal data
 	variants := make([]dictionary.Lemma, 0, len(lexItems))
 	for i, item := range lexItems {
 		corpusEntry, err := actions.searchCorpusLemma(ctx, corpusId, item.Lemma, item.Pos)

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -160,7 +160,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 
 	// we get data for first match, the rest are suggestions
 	bestMatch := bestMatches[0]
-	suggestions := collections.SliceMap(bestMatches[1:], func(match dictionary.Lemma, i int) string { return match.Lemma })
+	corpSuggestions := collections.SliceMap(bestMatches[1:], func(match dictionary.Lemma, i int) string { return match.Lemma })
 
 	// find available sources for the best match, and select the main source based on the priority list
 	sources, err := SearchAvailableSources(ctx, actions.db.DB(), bestMatch.Lemma)
@@ -178,7 +178,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	if mainSource == "" {
 		ans := map[string]any{
 			"matches":     []dictionary.Lemma{bestMatch},
-			"suggestions": suggestions,
+			"suggestions": corpSuggestions,
 		}
 		uniresp.WriteJSONResponse(ctx.Writer, ans)
 		return
@@ -195,7 +195,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	if lexItems == nil {
 		ans := map[string]any{
 			"matches":     []dictionary.Lemma{bestMatch},
-			"suggestions": suggestions,
+			"suggestions": corpSuggestions,
 		}
 		uniresp.WriteJSONResponse(ctx.Writer, ans)
 		return
@@ -234,11 +234,12 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 			Variant:    item,
 		}
 		variants = append(variants, *corpusEntry)
+		corpSuggestions = collections.SliceFilter(corpSuggestions, func(suggestion string, i int) bool { return suggestion != item.Lemma })
 	}
 
 	ans := map[string]any{
 		"matches":     variants,
-		"suggestions": append(suggestions, typoSuggestions...),
+		"suggestions": append(corpSuggestions, typoSuggestions...),
 	}
 	uniresp.WriteJSONResponse(ctx.Writer, ans)
 }

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -45,29 +45,22 @@ type Handler struct {
 	sourcePriority []Source
 }
 
-func (actions *Handler) getQueryMatches(ctx context.Context, corpusId, term string) ([]dictionary.Lemma, error) {
+func (actions *Handler) findBestQueryMatches(ctx context.Context, corpusId, term string) ([]dictionary.Lemma, error) {
 	datasetSize, err := actions.dictActions.GetDatasetSize(corpusId)
 	if err != nil {
-		return nil, err
+		return []dictionary.Lemma{}, err
 	}
 
-	ans, err := dictionary.Search(
+	return dictionary.Search(
 		ctx,
 		actions.db,
 		corpusId,
 		dictionary.SearchWithAnyValue(term),
 		dictionary.SearchWithDatasetSizeForIPM(int(datasetSize)),
 	)
-	if err != nil {
-		return []dictionary.Lemma{}, fmt.Errorf("failed to find lemma: %w", err)
-	}
-	if len(ans) > 0 {
-		return ans, nil
-	}
-	return []dictionary.Lemma{}, nil
 }
 
-func (actions *Handler) searchCorpusLemma(ctx context.Context, corpusId, lemma, pos string) (*dictionary.Lemma, error) {
+func (actions *Handler) searchCorpusEntry(ctx context.Context, corpusId, lemma, pos string) (*dictionary.Lemma, error) {
 	if lemma == "" {
 		return nil, nil
 	}
@@ -107,7 +100,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	term := ctx.Param("term")
 
 	// search corpus for possible lemmata of the word, corpus is used for lematization and to get the dataset size for IPM calculation
-	bestMatches, err := actions.getQueryMatches(ctx, corpusId, term)
+	bestMatches, err := actions.findBestQueryMatches(ctx, corpusId, term)
 	if err != nil {
 		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
 		return
@@ -211,7 +204,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	// for each variant, search for its entry in the corpus, if not found, create a new entry with minimal data
 	variants := make([]dictionary.Lemma, 0, len(lexItems))
 	for i, item := range lexItems {
-		corpusEntry, err := actions.searchCorpusLemma(ctx, corpusId, item.Lemma, item.Pos)
+		corpusEntry, err := actions.searchCorpusEntry(ctx, corpusId, item.Lemma, item.Pos)
 		if err != nil {
 			uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
 			return
@@ -226,6 +219,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 				Sublemmas: []dictionary.Sublemma{{Value: item.Lemma}},
 			}
 		} else {
+			corpusEntry.ID = fmt.Sprintf("corp-%d", i)
 			corpusEntry.Specifier = cmp.Or(corpusEntry.Specifier, cmp.Or(item.Gender, item.Aspect))
 			corpusEntry.Sublemmas = collections.SliceFilter(corpusEntry.Sublemmas, func(sublemma dictionary.Sublemma, i int) bool {
 				return sublemma.Value == item.Lemma

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -185,13 +185,21 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 		}
 		if corpusEntry == nil {
 			corpusEntry = &dictionary.Lemma{
-				ID:        fmt.Sprintf("match-%d", i),
+				ID:        fmt.Sprintf("lex-%d", i),
 				Lemma:     item.Lemma,
 				PoS:       item.Pos,
 				Specifier: cmp.Or(item.Gender, item.Aspect),
 				Forms:     []dictionary.Form{{Value: item.Lemma, Sublemma: item.Lemma}},
 				Sublemmas: []dictionary.Sublemma{{Value: item.Lemma}},
 			}
+		} else {
+			corpusEntry.Specifier = cmp.Or(corpusEntry.Specifier, cmp.Or(item.Gender, item.Aspect))
+			corpusEntry.Sublemmas = collections.SliceFilter(corpusEntry.Sublemmas, func(sublemma dictionary.Sublemma, i int) bool {
+				return sublemma.Value == item.Lemma
+			})
+			corpusEntry.Forms = collections.SliceFilter(corpusEntry.Forms, func(form dictionary.Form, i int) bool {
+				return form.Sublemma == item.Lemma
+			})
 		}
 		corpusEntry.ExtraData = LexExtraData{
 			CorpusId:   corpusId,

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -106,20 +106,35 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 	corpusId := ctx.Param("corpusId")
 	term := ctx.Param("term")
 
-	// search corpus for possible lemmata of the word
+	// search corpus for possible lemmata of the word, corpus is used for lematization and to get the dataset size for IPM calculation
 	bestMatches, err := actions.getQueryMatches(ctx, corpusId, term)
 	if err != nil {
 		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
 		return
 	}
 
-	// if empty corpus matches, use different sources
+	// if empty corpus matches, use ujc sources directly
 	if len(bestMatches) == 0 {
-		bestMatches, err = SearchMatches(ctx, actions.db.DB(), term, SourceASSC)
-		if err != nil {
-			uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
-			return
+		for _, source := range actions.sourcePriority {
+			bestMatches, err = SearchMatches(ctx, actions.db.DB(), term, source)
+			if err != nil {
+				uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
+				return
+			}
+			if len(bestMatches) > 0 {
+				break
+			}
 		}
+	}
+
+	// no matches found in any source, return empty result
+	if len(bestMatches) == 0 {
+		ans := map[string]any{
+			"matches":     make([]dictionary.Lemma, 0),
+			"suggestions": make([]string, 0),
+		}
+		uniresp.WriteJSONResponse(ctx.Writer, ans)
+		return
 	}
 
 	// remove lemma duplicates

--- a/ujc/lex/handler.go
+++ b/ujc/lex/handler.go
@@ -127,11 +127,17 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 		}
 	}
 
+	typoSuggestions, err := SearchTypoSuggestions(ctx, actions.db.DB(), term)
+	if err != nil {
+		uniresp.RespondWithErrorJSON(ctx, err, http.StatusInternalServerError)
+		return
+	}
+
 	// no matches found in any source, return empty result
 	if len(bestMatches) == 0 {
 		ans := map[string]any{
 			"matches":     make([]dictionary.Lemma, 0),
-			"suggestions": make([]string, 0),
+			"suggestions": typoSuggestions,
 		}
 		uniresp.WriteJSONResponse(ctx.Writer, ans)
 		return
@@ -226,7 +232,7 @@ func (actions *Handler) SearchWord(ctx *gin.Context) {
 
 	ans := map[string]any{
 		"matches":     variants,
-		"suggestions": suggestions,
+		"suggestions": append(suggestions, typoSuggestions...),
 	}
 	uniresp.WriteJSONResponse(ctx.Writer, ans)
 }


### PR DESCRIPTION
- return empty results if no matches found, do not continue
- if no matches found in corpus search ujc sources by priority
- implemented typo suggestions - search without diacritics, s/z and i/y interchanges